### PR TITLE
Replace yanked ffi 1.9.7 with 1.9.8

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,7 +45,7 @@ GEM
     docile (1.1.5)
     erubis (2.7.0)
     excon (0.13.4)
-    ffi (1.9.7)
+    ffi (1.9.8)
     fog (1.3.1)
       builder
       excon (~> 0.13.0)
@@ -199,3 +199,6 @@ DEPENDENCIES
   rspec-rails (~> 3.0)
   simplecov
   sqlite3
+
+BUNDLED WITH
+   1.10.3


### PR DESCRIPTION
Fixes:

```
⚡︎ master ~/P/hyper/hyper-recipes ∴ bundle
Fetching gem metadata from https://rubygems.org/.........
Fetching version metadata from https://rubygems.org/...
Fetching dependency metadata from https://rubygems.org/..
Could not find ffi-1.9.7 in any of the sources
```

From https://rubygems.org/gems/ffi/versions:

`1.9.7 - March 13, 2015 (861 KB) yanked`
