### PR TITLE
move "register for token" part to separate file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Introduction
 
-This is the backend for the Hyper Recipes app, to be able to use it, you will need an access token that your contact inside Hyper will provide you with when you begin your quest. This is helpful so other applicants don't modify your recipes in any way.
+This is the backend for the Hyper Recipes app. To be able to use it, you will need an access token that your contact inside Hyper will provide you with when you begin your quest. This is helpful so other applicants don't modify your recipes in any way.
 
 The base HTTP endpoints is: `http://hyper-recipes.herokuapp.com`
 

--- a/README.md
+++ b/README.md
@@ -1,37 +1,9 @@
 # Introduction
 
-This is the backend for the Hyper Recipes app, to be able to use it you first have to register and use the provided token, this is helpful so other applicants don't modify your recipes in any way.
+This is the backend for the Hyper Recipes app, to be able to use it, you will need an access token that your contact inside Hyper will provide you with when you begin your quest. This is helpful so other applicants don't modify your recipes in any way.
 
 The base HTTP endpoints is: `http://hyper-recipes.herokuapp.com`
 
-## Register to get a token
-
-* **email:string** (obligatory field, must be valid email format)
-* **password** (obligatory field)
-* **password_confirmation** (obligatory field)
-* seed_recipes:boolean
-
-### HTTP
-`POST`: `/users`
-
-Sample:
-
-```json
-{
-  "user": {
-    "email": "user@example.com",
-    "password": "secret",
-    "password_confirmation": "secret",
-    "seed_recipes": true
-  }
-}
-```
-In Curl it would be something like that:
-```
-curl -d "user[email]=user@example.com" -d "user[password]=password" -d "user[password_confirmation]=password" -d "user[seed_recipes]=true" http://hyper-recipes.herokuapp.com/users
-```
-
-When you successfully create a user you'll get a token in the json response, use that in any further communications with the API, you need to set a request header with `Authorization` and use the generate auth_token.
 
 ## Retrieve recipes
 

--- a/register_user.md
+++ b/register_user.md
@@ -1,0 +1,32 @@
+# For Hyper staff, not relevant for applicants
+
+How to register an applicant to obtain an access token
+
+## Register to get a token
+
+* **email:string** (obligatory field, must be valid email format)
+* **password** (obligatory field)
+* **password_confirmation** (obligatory field)
+* seed_recipes:boolean
+
+### HTTP
+`POST`: `/users`
+
+Sample:
+
+```json
+{
+  "user": {
+    "email": "user@example.com",
+    "password": "secret",
+    "password_confirmation": "secret",
+    "seed_recipes": true
+  }
+}
+```
+In Curl it would be something like that:
+```
+curl -d "user[email]=user@example.com" -d "user[password]=password" -d "user[password_confirmation]=password" -d "user[seed_recipes]=true" http://hyper-recipes.herokuapp.com/users
+```
+
+When you successfully create a user you'll get a token in the json response, pass that on to the applicant an inform him/her to use that in all communications with the API. They will need to set a request header with `Authorization` and use the generated auth_token.


### PR DESCRIPTION
to avoid confusion for applicants looking for endpoint information
